### PR TITLE
Only require PHPUnit test cases in MockBuilder signature.

### DIFF
--- a/src/Xpmock/MockWriter.php
+++ b/src/Xpmock/MockWriter.php
@@ -29,7 +29,7 @@ class MockWriter
      * @param TestCase $testCase
      * @param bool $isStub
      */
-    public function __construct($className, TestCase $testCase, $isStub = false)
+    public function __construct($className, PhpUnitTestCase $testCase, $isStub = false)
     {
         $this->className = (string) $className;
         $this->testCase = $testCase;


### PR DESCRIPTION
This is necessary for the Xpmock\TestCaseTrait to work without extending the Xpmock\TestCase , as creates a mock builder with the test case that it's running in.
